### PR TITLE
update kube-vip to 0.4.0 to remove need of static ToR routes

### DIFF
--- a/modules/controller_pool/controller-primary.tpl
+++ b/modules/controller_pool/controller-primary.tpl
@@ -109,10 +109,7 @@ EOF
 
 function kube_vip {
   kubectl --kubeconfig=/etc/kubernetes/admin.conf apply -f https://kube-vip.io/manifests/rbac.yaml
-  GATEWAY_IP=$(curl https://metadata.platformequinix.com/metadata | jq -r ".network.addresses[] | select(.public == false) | .gateway");
-  ip route add 169.254.255.1 via $GATEWAY_IP
-  ip route add 169.254.255.2 via $GATEWAY_IP
-  docker run --network host --rm ghcr.io/kube-vip/kube-vip:v0.3.8 manifest daemonset \
+  docker run --network host --rm ghcr.io/kube-vip/kube-vip:v0.4.0 manifest daemonset \
   --interface lo \
   --services \
   --bgp \


### PR DESCRIPTION
Signed-off-by: Marques Johansson <mjohansson@equinix.com>